### PR TITLE
Fix link reference to python sdk documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To learn how to use this template:
 
 * [Follow the guide to writing a composition function in Python][function guide]
 * [Learn about how composition functions work][functions]
-* [Read the function-sdk-go package documentation][package docs]
+* [Read the function-sdk-python package documentation][package docs]
 
 If you just want to jump in and get started:
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fix link reference to python sdk documentation, the description was referring to `go` whereas it should refer to `python`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
