### PR TITLE
fix(tests): fix want/got mapping in test output

### DIFF
--- a/tests/test_fn.py
+++ b/tests/test_fn.py
@@ -49,8 +49,8 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
         for case in cases:
             got = await runner.RunFunction(case.req, None)
             self.assertEqual(
-                json_format.MessageToDict(got),
                 json_format.MessageToDict(case.want),
+                json_format.MessageToDict(got),
                 "-want, +got",
             )
 


### PR DESCRIPTION
### Description of your changes

Fixed the mapping of the want/got output in the test example so that it's not reversed.

I have:

- [X] Read and followed Crossplane's [contribution process].
~- [ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
