### PR TITLE
Pin to max Python 3.12, move around some ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "function"
 description = 'A composition function'
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "Crossplane Maintainers", email = "info@crossplane.io" }]
@@ -14,6 +14,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
@@ -66,6 +67,8 @@ unit = "python -m unittest tests/*.py"
 [tool.ruff]
 target-version = "py311"
 exclude = ["function/proto/*"]
+
+[tool.ruff.lint]
 select = [
   "A",
   "ARG",
@@ -101,7 +104,7 @@ ignore = ["ISC001"] # Ruff warns this is incompatible with ruff format.
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D"] # Don't require docstrings for tests.
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["function"]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/function-template-python/issues/65

Note that the Docker image we use has Python 3.11, so functions will always run with that version regardless of whether you have 3.12 locally. (Unless you choose to use a different base image.)

The ruff config tweaks are because they moved some config around with a newer version that was updated by renovate a while back.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
