### PR TITLE
Change requires-python to match Docker image constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "function"
 description = 'A composition function'
 readme = "README.md"
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11,<3.12"
 license = "Apache-2.0"
 keywords = []
 authors = [{ name = "Crossplane Maintainers", email = "info@crossplane.io" }]
@@ -14,7 +14,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [


### PR DESCRIPTION
### Description of your changes

gcr.io/distroless/python3-debian12 is debian12 with python3.11 so package should not be marking by default that it is compatible with 3.12

I have:

- [x] Read and followed Crossplane's [contribution process].
- [] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
