### PR TITLE
feat: add init.sh post-initialization script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This script helps initialize a new function project by
+# replacing all instances of function-template-python with the
+# name of your function. The script accepts two arguments:
+# 1. The name of your function
+# 2. The path to your function directory
+
+set -e
+
+cd "$2" || return
+
+# Replace function-template-python with the name of your function
+# in package/crossplane.yaml
+perl -pi -e s,function-template-python,"$1",g package/crossplane.yaml
+# in example YAML files
+find example -type f -print0 | xargs -0 -I {} perl -pi -e s,function-template-python,"$1",g {}
+
+echo "Function $1 has been initialized successfully"


### PR DESCRIPTION
Closes #88

## What and Why

Added an `init.sh` post-initialization script that automatically replaces all instances of `function-template-python` with the user's function name when the Crossplane CLI runs `xpkg init`.

This script updates:
- `package/crossplane.yaml` — the Function resource metadata name
- `example/*.yaml` — example function references

Previously, users cloning this template via `crossplane xpkg init` had to manually replace the template name in multiple files. With this init script, the CLI handles it automatically.

## How to Test

```bash
# Simulate what crossplane xpkg init does:
git clone https://github.com/crossplane/function-template-python my-function
sh my-function/init.sh "my-function" "my-function"

# Verify replacements:
grep -r "function-template-python" my-function/package/ my-function/example/
# Should return nothing (no template references remaining)
```

### Description of your changes

Added `init.sh` following the same pattern as [function-template-go/init.sh](https://github.com/crossplane/function-template-go/blob/main/init.sh).

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Not applicable — added a shell script, no unit tests needed.

[contribution process]: https://git.io/fj2m9
