### PR TITLE
feat: add init.sh post-initialization script (#88)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This script helps initialize a new function project by
+# replacing all instances of function-template-python with the
+# name of your function. The script accepts two arguments:
+# 1. The name of your function
+# 2. The path to your function directory
+
+set -e
+
+cd "$2" || return
+
+# Replace function-template-python with the name of your function
+# in package/crossplane.yaml
+perl -pi -e s,function-template-python,"$1",g package/crossplane.yaml
+# in example YAML files
+find example -type f -print0 | xargs -0 -I {} perl -pi -e s,function-template-python,"$1",g {}
+
+echo "Function $1 has been initialized successfully"


### PR DESCRIPTION
Closes #88

Add a post-initialization script that replaces all instances of
crossplane/function-template-python in the repository with the user's
own function name. This enables `xpkg init` to correctly set up the
template after cloning.

Changes in this PR:
- Added `init.sh` post-initialization script that runs automatically
  during `xpkg init`
- Replaces `crossplane/function-template-python` in:
  - `package/crossplane.yaml` (the Function resource name)
  - `example/aws-loadbalancer-kube-proxy-provider.yaml`
  - `example/aws-s3-bucket-provider.yaml`

## How to Test

1. Run `xpkg init crossplane/function-template-python --target my-function`
2. Verify that `package/crossplane.yaml` and `example/*.yaml` are replaced with the new function name